### PR TITLE
Allow recipes from subdirectories

### DIFF
--- a/bincrafters/build_template_boost_default.py
+++ b/bincrafters/build_template_boost_default.py
@@ -6,9 +6,9 @@ from bincrafters import build_template_default
 from conans import tools
 
 
-def add_boost_shared(build):
+def add_boost_shared(build, recipe=None):
     if build_shared.is_shared():
-        shared_option_name = "%s:shared" % build_shared.get_name_from_recipe()
+        shared_option_name = "%s:shared" % build_shared.get_name_from_recipe(recipe=recipe)
         build.options.update({
             'boost_*:shared':
             build.options[shared_option_name]
@@ -20,7 +20,10 @@ def get_builder(shared_option_name=None,
                 pure_c=False,
                 dll_with_static_runtime=False,
                 build_policy=None,
+                cwd=None,
                 **kwargs):
+
+    recipe = build_shared.get_recipe_path(cwd)
 
     # Bincrafters default is to upload only when stable, but boost is an exception
     # Empty string allows boost packages upload for testing branch
@@ -32,7 +35,8 @@ def get_builder(shared_option_name=None,
             pure_c=pure_c,
             dll_with_static_runtime=dll_with_static_runtime,
             build_policy=build_policy,
+            cwd=cwd,
             **kwargs)
-        builder.builds = map(add_boost_shared, builder.items)
+        builder.builds = map(lambda item : add_boost_shared(item, recipe=recipe), builder.items)
 
         return builder

--- a/bincrafters/build_template_default.py
+++ b/bincrafters/build_template_default.py
@@ -7,11 +7,13 @@ def get_builder(shared_option_name=None,
                 pure_c=True,
                 dll_with_static_runtime=False,
                 build_policy=None,
+                cwd=None,
                 **kwargs):
+    recipe = build_shared.get_recipe_path(cwd)
 
-    builder = build_shared.get_builder(build_policy)
+    builder = build_shared.get_builder(build_policy, cwd=cwd, **kwargs)
     if shared_option_name is None and build_shared.is_shared():
-        shared_option_name = "%s:shared" % build_shared.get_name_from_recipe()
+        shared_option_name = "%s:shared" % build_shared.get_name_from_recipe(recipe=recipe)
 
     builder.add_common_builds(
         shared_option_name=shared_option_name,

--- a/tests/test_package_tools.py
+++ b/tests/test_package_tools.py
@@ -232,6 +232,7 @@ def test_format_mixed_remotes(set_mixed_remote_address):
     assert "https://api.bintray.com/conan/qux/baz" == remote.url
     assert True == remote.use_ssl
 
+
 def test_default_remote_address(set_upload_address):
     builder = build_template_default.get_builder()
     assert 2 == len(builder.remotes_manager._remotes)


### PR DESCRIPTION
- package tools need to get the recipe from the correct path
- This allows building bincrafters/conan-flex#4 on my machine