### PR TITLE
Accept Conanfile and Version by Argument

### DIFF
--- a/bincrafters/__init__.py
+++ b/bincrafters/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.18.3'
+__version__ = '0.18.4'

--- a/bincrafters/build_shared.py
+++ b/bincrafters/build_shared.py
@@ -9,8 +9,8 @@ from cpt.tools import split_colon_env
 from cpt.remotes import RemotesManager
 from bincrafters.build_paths import BINCRAFTERS_REPO_URL
 
-def get_recipe_path(cwd=None):
-    conanfile = os.getenv("CONAN_CONANFILE", "conanfile.py")
+def get_recipe_path(cwd=None, kwargs={}):
+    conanfile = kwargs.get("conanfile", os.getenv("CONAN_CONANFILE", "conanfile.py"))
     if cwd is None:
         return conanfile
     else:
@@ -42,17 +42,17 @@ def inspect_value_from_recipe(attribute, recipe_path):
 
 
 def get_name_from_recipe(recipe=None):
-    name = inspect_value_from_recipe(attribute="name", recipe_path=get_recipe_path())
+    name = inspect_value_from_recipe(attribute="name", recipe_path=get_recipe_path(kwargs={"conanfile": recipe}))
     return name or get_value_from_recipe(r'''name\s*=\s*["'](\S*)["']''', recipe=recipe).groups()[0]
 
 
 def get_version_from_recipe(recipe=None):
-    version = inspect_value_from_recipe(attribute="version", recipe_path=get_recipe_path())
+    version = inspect_value_from_recipe(attribute="version", recipe_path=get_recipe_path(kwargs={"conanfile": recipe}))
     return version or get_value_from_recipe(r'''version\s*=\s*["'](\S*)["']''', recipe=recipe).groups()[0]
 
 
 def is_shared(recipe=None):
-    options = inspect_value_from_recipe(attribute="options", recipe_path=get_recipe_path())
+    options = inspect_value_from_recipe(attribute="options", recipe_path=get_recipe_path(kwargs={"conanfile": recipe}))
     if options:
         return "shared" in options
 
@@ -119,7 +119,7 @@ def get_version(recipe=None):
 def get_conan_vars(recipe=None, kwargs={}):
     username = kwargs.get("username", os.getenv("CONAN_USERNAME", get_username_from_ci() or "bincrafters"))
     kwargs["channel"] = kwargs.get("channel", os.getenv("CONAN_CHANNEL", get_channel_from_ci()))
-    version = os.getenv("CONAN_VERSION", get_version(recipe=recipe))
+    version = kwargs.get("version", os.getenv("CONAN_VERSION", get_version(recipe=recipe)))
     kwargs["login_username"] = kwargs.get("login_username", os.getenv("CONAN_LOGIN_USERNAME", username))
     kwargs["username"] = username
 
@@ -205,7 +205,7 @@ def get_reference(name, version, kwargs):
 
 
 def get_builder(build_policy=None, cwd=None, **kwargs):
-    recipe = get_recipe_path(cwd)
+    recipe = get_recipe_path(cwd, kwargs)
     name = get_name_from_recipe(recipe=recipe)
     username, version, kwargs = get_conan_vars(recipe=recipe, kwargs=kwargs)
     kwargs = get_reference(name, version, kwargs)

--- a/tests/test_package_tools.py
+++ b/tests/test_package_tools.py
@@ -216,7 +216,7 @@ def test_format_multi_remotes(set_multi_remote_address):
     builder = build_template_default.get_builder()
     assert 2 == len(builder.remotes_manager._remotes)
     remote = builder.remotes_manager._remotes[0]
-    assert "remotefoo" == remote.name
+    assert "remote0" == remote.name
     assert "https://api.bintray.com/conan/foo/bar" == remote.url
     assert remote.use_ssl
     remote = builder.remotes_manager._remotes[1]
@@ -245,5 +245,5 @@ def test_default_remote_address(set_upload_address):
     assert "remotefoo" == remote.name
     assert "https://api.bintray.com/conan/foo/bar" == remote.url
     remote = builder.remotes_manager._remotes[1]
-    assert "upload_repo" == remote.name
+    assert "remote1" == remote.name
     assert "https://api.bintray.com/conan/bincrafters/public-conan" == remote.url

--- a/tests/test_package_tools.py
+++ b/tests/test_package_tools.py
@@ -216,7 +216,7 @@ def test_format_multi_remotes(set_multi_remote_address):
     builder = build_template_default.get_builder()
     assert 2 == len(builder.remotes_manager._remotes)
     remote = builder.remotes_manager._remotes[0]
-    assert "remote0" == remote.name
+    assert "remotefoo" == remote.name
     assert "https://api.bintray.com/conan/foo/bar" == remote.url
     assert remote.use_ssl
     remote = builder.remotes_manager._remotes[1]
@@ -245,5 +245,5 @@ def test_default_remote_address(set_upload_address):
     assert "remotefoo" == remote.name
     assert "https://api.bintray.com/conan/foo/bar" == remote.url
     remote = builder.remotes_manager._remotes[1]
-    assert "remote1" == remote.name
+    assert "upload_repo" == remote.name
     assert "https://api.bintray.com/conan/bincrafters/public-conan" == remote.url


### PR DESCRIPTION
When you want to build multiple recipes on same CPT container, Bincrafters Package Tools is not able to handle different recipes names at same time, and the recipe version is collected by env var.