### PR TITLE
Fix AZP builds when building a Pull Request build

### DIFF
--- a/bincrafters/build_shared.py
+++ b/bincrafters/build_shared.py
@@ -97,7 +97,7 @@ def get_ci_vars():
     repobranch_split = repobranch.split("/")
 
     username, _ = reponame_split if len(reponame_split) > 1 else ["", ""]
-    channel, version = repobranch_split if len(repobranch_split) > 1 else ["", ""]
+    channel, version = repobranch_split if (len(repobranch_split) > 1 and repobranch_split[1] != 'pull') else ["", ""]
     return username, channel, version
 
 


### PR DESCRIPTION
When building a PR the BUILD_SOURCEBRANCH is like 'ref/pull/1/merge',
which breaks the build by "too many values to unpack (expected 2)"

See https://dev.azure.com/bincrafters/packages/_build/results?buildId=567