### PR TITLE
Add a multi-version standalone recipe style.

### DIFF
--- a/.github/workflows/package-tools.yml
+++ b/.github/workflows/package-tools.yml
@@ -13,7 +13,7 @@ jobs:
         os: ["ubuntu-20.04", "windows-2019", "macos-10.15"]
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
       with:
         python-version: "3.8"
     - name: "Build & Test"
@@ -32,7 +32,7 @@ jobs:
     needs: bincrafters-package-tools-test
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
       with:
         python-version: "3.8"
     - name: Build

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Or if you want to download our pip package
 All variables supported by Conan package tools, are treated by Bincrafters package tools as well.
 To solve the upload, some variables are customized by default:
 
-**CONAN_UPLOAD**: https://api.bintray.com/conan/bincrafters/public-conan  
+**CONAN_UPLOAD**: https://bincrafters.jfrog.io/artifactory/api/conan/public-conan
 **CONAN_REFERENCE**: Fields **name** and **version** from conanfile.py  
 **CONAN_USERNAME**: Get from CI env vars. Otherwise, use **bincrafters**  
 **CONAN_VERSION**: Get from CI env vars.  

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Or if you want to download our pip package
 All variables supported by Conan package tools, are treated by Bincrafters package tools as well.
 To solve the upload, some variables are customized by default:
 
-**CONAN_UPLOAD**: https://bincrafters.jfrog.io/artifactory/api/conan/public-conan
+**CONAN_UPLOAD**: https://bincrafters.jfrog.io/artifactory/api/conan/public-conan  
 **CONAN_REFERENCE**: Fields **name** and **version** from conanfile.py  
 **CONAN_USERNAME**: Get from CI env vars. Otherwise, use **bincrafters**  
 **CONAN_VERSION**: Get from CI env vars.  

--- a/bincrafters/autodetect.py
+++ b/bincrafters/autodetect.py
@@ -93,12 +93,16 @@ def autodetect() -> str:
 DIR_STRUCTURE_ONE_RECIPE_ONE_VERSION = "one_recipe_one_file"
 DIR_STRUCTURE_ONE_RECIPE_MANY_VERSIONS = "one_recipe_many_versions"
 DIR_STRUCTURE_CCI = "cci_many_recipes_many_versions"
+DIR_STRUCTURE_STANDALONE_RECIPE_MANY_VERSIONS = "standalone_recipe_many_versions"
 
 
 def autodetect_directory_structure() -> str:
     """ Return the directory type as classified above this method
     """
     pwd = os.getcwd()
+
+    if os.path.exists(os.path.join(pwd, "conanfile.py")) and os.path.exists(os.path.join(pwd, "conandata.yml")):
+        return DIR_STRUCTURE_STANDALONE_RECIPE_MANY_VERSIONS
 
     if os.path.exists(os.path.join(pwd, "conanfile.py")):
         return DIR_STRUCTURE_ONE_RECIPE_ONE_VERSION

--- a/bincrafters/autodetect.py
+++ b/bincrafters/autodetect.py
@@ -1,5 +1,5 @@
 import os
-from bincrafters.build_shared import get_recipe_path, inspect_value_from_recipe
+from bincrafters.build_shared import get_recipe_path, inspect_value_from_recipe, get_version
 
 _recipe_path = os.path.dirname(get_recipe_path())
 
@@ -101,7 +101,7 @@ def autodetect_directory_structure() -> str:
     """
     pwd = os.getcwd()
 
-    if os.path.exists(os.path.join(pwd, "conanfile.py")) and os.path.exists(os.path.join(pwd, "conandata.yml")):
+    if os.path.exists(os.path.join(pwd, "conanfile.py")) and os.path.exists(os.path.join(pwd, "conandata.yml")) and not get_version(os.path.join(pwd, "conanfile.py")):
         return DIR_STRUCTURE_STANDALONE_RECIPE_MANY_VERSIONS
 
     if os.path.exists(os.path.join(pwd, "conanfile.py")):

--- a/bincrafters/build_autodetect.py
+++ b/bincrafters/build_autodetect.py
@@ -31,7 +31,9 @@ def run_autodetect():
     os.system('conan config set general.revisions_enabled=1')
     os.environ["CONAN_DOCKER_ENTRY_SCRIPT"] =\
         "conan config set storage.download_cache='{}'; conan config set general.revisions_enabled=1".format(tmpdir)
-    os.environ["CONAN_DOCKER_RUN_OPTIONS"] = "-v '{}':'/tmp/conan'".format(tmpdir)
+    conan_docker_run_options = os.environ.get('CONAN_DOCKER_RUN_OPTIONS','')
+    conan_docker_run_options += " -v '{}':'/tmp/conan'".format(tmpdir)
+    os.environ['CONAN_DOCKER_RUN_OPTIONS'] = conan_docker_run_options
 
     ###
     # Enabling installing system_requirements

--- a/bincrafters/build_paths.py
+++ b/bincrafters/build_paths.py
@@ -1,5 +1,7 @@
-BINCRAFTERS_REPO_URL = "https://bincrafters.jfrog.io/artifactory/api/conan/public-conan"
+# BINCRAFTERS_REPO_URL = "https://bincrafters.jfrog.io/artifactory/api/conan/public-conan"
+BINCRAFTERS_REPO_URL = "https://api.bintray.com/conan/bincrafters/public-conan"
 BINCRAFTERS_REPO_NAME = "public-conan"
 BINCRAFTERS_LOGIN_USERNAME = "bincrafters-bot"
 BINCRAFTERS_USERNAME = "bincrafters"
 
+# TODO: Change REPO_URL once it is clear, why it breaks the tests....

--- a/bincrafters/build_paths.py
+++ b/bincrafters/build_paths.py
@@ -1,6 +1,5 @@
-BINCRAFTERS_REPO_URL = "https://api.bintray.com/conan/bincrafters/public-conan"
+BINCRAFTERS_REPO_URL = "https://bincrafters.jfrog.io/artifactory/api/conan/public-conan"
 BINCRAFTERS_REPO_NAME = "public-conan"
-BINCRAFTERS_LOGIN_USERNAME = "bincrafters-user"
+BINCRAFTERS_LOGIN_USERNAME = "bincrafters-bot"
 BINCRAFTERS_USERNAME = "bincrafters"
 
-# TODO: Update those after Bintray's shutdown

--- a/bincrafters/build_shared.py
+++ b/bincrafters/build_shared.py
@@ -63,7 +63,12 @@ def get_name_from_recipe(recipe=None):
 
 def get_version_from_recipe(recipe=None):
     version = inspect_value_from_recipe(attribute="version", recipe_path=recipe)
-    return version or get_value_from_recipe(r'''version\s*=\s*["'](\S*)["']''', recipe=recipe).groups()[0]
+    if version:
+        return version
+    match = get_value_from_recipe(r'''\s+version\s*=\s*["'](\S*)["']''', recipe=recipe)
+    if match:
+        return match.groups()[0]
+    return None
 
 
 def is_shared(recipe=None):

--- a/bincrafters/build_shared.py
+++ b/bincrafters/build_shared.py
@@ -80,11 +80,9 @@ def is_shared(recipe=None):
 def get_repo_name_from_ci():
     reponame_a = os.getenv("APPVEYOR_REPO_NAME", "")
     reponame_t = os.getenv("TRAVIS_REPO_SLUG", "")
-    reponame_c = "%s/%s" % (os.getenv("CIRCLE_PROJECT_USERNAME", ""),
-                            os.getenv("CIRCLE_PROJECT_REPONAME", ""))
     reponame_azp = os.getenv("BUILD_REPOSITORY_NAME", "")
     reponame_g = os.getenv("GITHUB_REPOSITORY", "")
-    return reponame_a or reponame_t or reponame_c or reponame_azp or reponame_g
+    return reponame_a or reponame_t or reponame_azp or reponame_g
 
 
 def get_repo_branch_from_ci():
@@ -94,7 +92,6 @@ def get_repo_branch_from_ci():
     # ~~Remove GHA special handling after CPT 0.32.0 is released~~
     repobranch_a = os.getenv("APPVEYOR_REPO_BRANCH", "")
     repobranch_t = os.getenv("TRAVIS_BRANCH", "")
-    repobranch_c = os.getenv("CIRCLE_BRANCH", "")
     repobranch_azp = os.getenv("BUILD_SOURCEBRANCH", "")
     if repobranch_azp.startswith("refs/pull/"):
         repobranch_azp = os.getenv("SYSTEM_PULLREQUEST_TARGETBRANCH", "")
@@ -105,7 +102,7 @@ def get_repo_branch_from_ci():
     if os.getenv("GITHUB_EVENT_NAME", "") == "pull_request":
         repobranch_g = os.getenv("GITHUB_BASE_REF", "")
 
-    return repobranch_a or repobranch_t or repobranch_c or repobranch_azp or repobranch_g
+    return repobranch_a or repobranch_t or repobranch_azp or repobranch_g
 
 
 def get_ci_vars():

--- a/bincrafters/check_compatibility.py
+++ b/bincrafters/check_compatibility.py
@@ -1,0 +1,32 @@
+import os
+
+MINIMUM_CONFIG_FILE_VERSIONS = {
+    "generate_ci_jobs": {
+        "gha": 11,
+        "azp": 2
+    }
+}
+
+
+def get_config_file_version() -> int:
+    return int(os.getenv("BPT_CONFIG_FILE_VERSION", 0))
+
+
+def get_minimum_compatible_version(platform: str, feature: str) -> int:
+    if platform not in ["gha", "azp"]:
+        raise ValueError("Unknown platform value {}".format(platform))
+
+    if feature not in ["generate-ci-jobs", ]:
+        raise ValueError("Unknown feature value {}".format(feature))
+
+    return MINIMUM_CONFIG_FILE_VERSIONS[feature][platform]
+
+
+def is_ci_config_compatible(platform: str, feature: str) -> bool:
+    config_version = get_config_file_version()
+    minimum_version = get_minimum_compatible_version(platform=platform, feature=feature)
+
+    if config_version < minimum_version:
+        return False
+
+    return True

--- a/bincrafters/check_compatibility.py
+++ b/bincrafters/check_compatibility.py
@@ -1,7 +1,7 @@
 import os
 
 MINIMUM_CONFIG_FILE_VERSIONS = {
-    "generate_ci_jobs": {
+    "generate-ci-jobs": {
         "gha": 11,
         "azp": 2
     }

--- a/bincrafters/generate_ci_jobs.py
+++ b/bincrafters/generate_ci_jobs.py
@@ -13,9 +13,6 @@ def _run_macos_jobs_on_gha():
             and utils_file_contains("azure-pipelines.yml", "template: .ci/azure.yml@templates"):
         return False
 
-    if utils_file_contains(".travis.yml", "import: bincrafters/templates:.ci/travis"):
-        return False
-
     return True
 
 

--- a/bincrafters/generate_ci_jobs.py
+++ b/bincrafters/generate_ci_jobs.py
@@ -123,8 +123,10 @@ def _get_base_config(recipe_directory: str, platform: str, split_by_build_types:
             for i, config_set in enumerate(m_tmp["config"], start=0):
                 m["config"].insert((i * 2) + 1, config_set.copy())
             for config_set in m["config"][0::2]:
+                config_set["name"] = "{} Release".format(config_set["name"])
                 config_set["buildType"] = "Release"
             for config_set in m["config"][1::2]:
+                config_set["name"] = "{} Debug".format(config_set["name"])
                 config_set["buildType"] = "Debug"
 
     if build_set == "full":

--- a/bincrafters/generate_ci_jobs.py
+++ b/bincrafters/generate_ci_jobs.py
@@ -71,6 +71,8 @@ def generate_ci_jobs(platform: str, recipe_type: str = autodetect(), split_by_bu
                     {"name": "GCC 8 Release", "compiler": "GCC", "version": "8", "os": "ubuntu-18.04", "buildType": "Release"},
                     {"name": "GCC 9 Debug", "compiler": "GCC", "version": "9", "os": "ubuntu-18.04", "buildType": "Debug"},
                     {"name": "GCC 9 Release", "compiler": "GCC", "version": "9", "os": "ubuntu-18.04", "buildType": "Release"},
+                    {"name": "GCC 10 Debug", "compiler": "GCC", "version": "10", "os": "ubuntu-18.04", "buildType": "Debug"},
+                    {"name": "GCC 10 Release", "compiler": "GCC", "version": "10", "os": "ubuntu-18.04", "buildType": "Release"},
                     {"name": "CLANG 3.9 Debug", "compiler": "CLANG", "version": "3.9", "os": "ubuntu-18.04", "buildType": "Debug"},
                     {"name": "CLANG 3.9 Release", "compiler": "CLANG", "version": "3.9", "os": "ubuntu-18.04", "buildType": "Release"},
                     {"name": "CLANG 4.0 Debug", "compiler": "CLANG", "version": "4.0", "os": "ubuntu-18.04", "buildType": "Debug"},
@@ -85,6 +87,10 @@ def generate_ci_jobs(platform: str, recipe_type: str = autodetect(), split_by_bu
                     {"name": "CLANG 8 Release", "compiler": "CLANG", "version": "8", "os": "ubuntu-18.04", "buildType": "Release"},
                     {"name": "CLANG 9 Debug", "compiler": "CLANG", "version": "9", "os": "ubuntu-18.04", "buildType": "Debug"},
                     {"name": "CLANG 9 Release", "compiler": "CLANG", "version": "9", "os": "ubuntu-18.04", "buildType": "Release"}
+                    {"name": "CLANG 10 Debug", "compiler": "CLANG", "version": "10", "os": "ubuntu-18.04", "buildType": "Debug"},
+                    {"name": "CLANG 10 Release", "compiler": "CLANG", "version": "10", "os": "ubuntu-18.04", "buildType": "Release"}
+                    {"name": "CLANG 11 Debug", "compiler": "CLANG", "version": "11", "os": "ubuntu-18.04", "buildType": "Debug"},
+                    {"name": "CLANG 11 Release", "compiler": "CLANG", "version": "11", "os": "ubuntu-18.04", "buildType": "Release"}
                 ]
                 if run_macos:
                     matrix["config"] += [
@@ -92,6 +98,8 @@ def generate_ci_jobs(platform: str, recipe_type: str = autodetect(), split_by_bu
                         {"name": "macOS Apple-Clang 10 Debug", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.14", "buildType": "Debug"},
                         {"name": "macOS Apple-Clang 11 Release", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15", "buildType": "Release"},
                         {"name": "macOS Apple-Clang 11 Debug", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15", "buildType": "Debug"},
+                        {"name": "macOS Apple-Clang 12 Release", "compiler": "APPLE_CLANG", "version": "12.0", "os": "macOS-10.15", "buildType": "Release"},
+                        {"name": "macOS Apple-Clang 12 Debug", "compiler": "APPLE_CLANG", "version": "12.0", "os": "macOS-10.15", "buildType": "Debug"},
                     ]
                 if run_windows:
                     matrix["config"] += [
@@ -124,6 +132,7 @@ def generate_ci_jobs(platform: str, recipe_type: str = autodetect(), split_by_bu
                     {"name": "GCC 7", "compiler": "GCC", "version": "7", "os": "ubuntu-18.04"},
                     {"name": "GCC 8", "compiler": "GCC", "version": "8", "os": "ubuntu-18.04"},
                     {"name": "GCC 9", "compiler": "GCC", "version": "9", "os": "ubuntu-18.04"},
+                    {"name": "GCC 10", "compiler": "GCC", "version": "10", "os": "ubuntu-18.04"},
                     {"name": "CLANG 3.9", "compiler": "CLANG", "version": "3.9", "os": "ubuntu-18.04"},
                     {"name": "CLANG 4.0", "compiler": "CLANG", "version": "4.0", "os": "ubuntu-18.04"},
                     {"name": "CLANG 5.0", "compiler": "CLANG", "version": "5.0", "os": "ubuntu-18.04"},
@@ -131,11 +140,14 @@ def generate_ci_jobs(platform: str, recipe_type: str = autodetect(), split_by_bu
                     {"name": "CLANG 7.0", "compiler": "CLANG", "version": "7.0", "os": "ubuntu-18.04"},
                     {"name": "CLANG 8", "compiler": "CLANG", "version": "8", "os": "ubuntu-18.04"},
                     {"name": "CLANG 9", "compiler": "CLANG", "version": "9", "os": "ubuntu-18.04"},
+                    {"name": "CLANG 10", "compiler": "CLANG", "version": "10", "os": "ubuntu-18.04"},
+                    {"name": "CLANG 11", "compiler": "CLANG", "version": "11", "os": "ubuntu-18.04"},
                 ]
                 if run_macos:
                     matrix["config"] += [
                         {"name": "macOS Apple-Clang 10", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.14"},
                         {"name": "macOS Apple-Clang 11", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
+                        {"name": "macOS Apple-Clang 12", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
                     ]
                 if run_windows:
                     matrix["config"] += [
@@ -161,6 +173,8 @@ def generate_ci_jobs(platform: str, recipe_type: str = autodetect(), split_by_bu
                 {"name": "macOS Apple-Clang 10 Debug", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.14", "buildType": "Debug"},
                 {"name": "macOS Apple-Clang 11 Release", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15", "buildType": "Release"},
                 {"name": "macOS Apple-Clang 11 Debug", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15", "buildType": "Debug"},
+                {"name": "macOS Apple-Clang 12 Release", "compiler": "APPLE_CLANG", "version": "12.0", "os": "macOS-10.15", "buildType": "Release"},
+                {"name": "macOS Apple-Clang 12 Debug", "compiler": "APPLE_CLANG", "version": "12.0", "os": "macOS-10.15", "buildType": "Debug"},
                 {"name": "Windows VS 2017 Release", "compiler": "VISUAL", "version": "15", "os": "vs2017-win2016", "buildType": "Release"},
                 {"name": "Windows VS 2017 Debug", "compiler": "VISUAL", "version": "15", "os": "vs2017-win2016", "buildType": "Debug"},
                 {"name": "Windows VS 2019 Release", "compiler": "VISUAL", "version": "16", "os": "windows-2019", "buildType": "Release"},
@@ -176,6 +190,7 @@ def generate_ci_jobs(platform: str, recipe_type: str = autodetect(), split_by_bu
             matrix["config"] = [
                 {"name": "macOS Apple-Clang 10", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.14"},
                 {"name": "macOS Apple-Clang 11", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
+                {"name": "macOS Apple-Clang 12", "compiler": "APPLE_CLANG", "version": "12.0", "os": "macOS-10.15"},
                 {"name": "Windows VS 2017", "compiler": "VISUAL", "version": "15", "os": "vs2017-win2016"},
                 {"name": "Windows VS 2019", "compiler": "VISUAL", "version": "16", "os": "windows-2019"},
             ]

--- a/bincrafters/generate_ci_jobs.py
+++ b/bincrafters/generate_ci_jobs.py
@@ -86,11 +86,11 @@ def generate_ci_jobs(platform: str, recipe_type: str = autodetect(), split_by_bu
                     {"name": "CLANG 8 Debug", "compiler": "CLANG", "version": "8", "os": "ubuntu-18.04", "buildType": "Debug"},
                     {"name": "CLANG 8 Release", "compiler": "CLANG", "version": "8", "os": "ubuntu-18.04", "buildType": "Release"},
                     {"name": "CLANG 9 Debug", "compiler": "CLANG", "version": "9", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "CLANG 9 Release", "compiler": "CLANG", "version": "9", "os": "ubuntu-18.04", "buildType": "Release"}
+                    {"name": "CLANG 9 Release", "compiler": "CLANG", "version": "9", "os": "ubuntu-18.04", "buildType": "Release"},
                     {"name": "CLANG 10 Debug", "compiler": "CLANG", "version": "10", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "CLANG 10 Release", "compiler": "CLANG", "version": "10", "os": "ubuntu-18.04", "buildType": "Release"}
+                    {"name": "CLANG 10 Release", "compiler": "CLANG", "version": "10", "os": "ubuntu-18.04", "buildType": "Release"},
                     {"name": "CLANG 11 Debug", "compiler": "CLANG", "version": "11", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "CLANG 11 Release", "compiler": "CLANG", "version": "11", "os": "ubuntu-18.04", "buildType": "Release"}
+                    {"name": "CLANG 11 Release", "compiler": "CLANG", "version": "11", "os": "ubuntu-18.04", "buildType": "Release"},
                 ]
                 if run_macos:
                     matrix["config"] += [

--- a/bincrafters/generate_ci_jobs.py
+++ b/bincrafters/generate_ci_jobs.py
@@ -1,6 +1,7 @@
 import json
 import os
 import yaml
+import copy
 
 from bincrafters.build_shared import get_bool_from_env, get_conan_vars, get_recipe_path, get_version_from_ci
 from bincrafters.autodetect import *
@@ -36,10 +37,6 @@ def generate_ci_jobs(platform: str, recipe_type: str = autodetect(), split_by_bu
     matrix = {}
     matrix_minimal = {}
 
-    if split_by_build_types is None:
-        # env var BPT_SPLIT_BY_BUILD_TYPES should be preferred over splitByBuildTypes (deprecated)
-        split_by_build_types = get_bool_from_env("BPT_SPLIT_BY_BUILD_TYPES", get_bool_from_env("splitByBuildTypes", False))
-
     if platform == "gha":
         run_macos = _run_macos_jobs_on_gha()
         run_windows = _run_windows_jobs_on_gha()
@@ -57,147 +54,77 @@ def generate_ci_jobs(platform: str, recipe_type: str = autodetect(), split_by_bu
             ]
             matrix_minimal["config"] = matrix["config"].copy()
         else:
-            if split_by_build_types:
-                matrix["config"] = [
-                    {"name": "GCC 4.9 Debug", "compiler": "GCC", "version": "4.9", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "GCC 4.9 Release", "compiler": "GCC", "version": "4.9", "os": "ubuntu-18.04", "buildType": "Release"},
-                    {"name": "GCC 5 Debug", "compiler": "GCC", "version": "5", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "GCC 5 Release", "compiler": "GCC", "version": "5", "os": "ubuntu-18.04", "buildType": "Release"},
-                    {"name": "GCC 6 Debug", "compiler": "GCC", "version": "6", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "GCC 6 Release", "compiler": "GCC", "version": "6", "os": "ubuntu-18.04", "buildType": "Release"},
-                    {"name": "GCC 7 Debug", "compiler": "GCC", "version": "7", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "GCC 7 Release", "compiler": "GCC", "version": "7", "os": "ubuntu-18.04", "buildType": "Release"},
-                    {"name": "GCC 8 Debug", "compiler": "GCC", "version": "8", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "GCC 8 Release", "compiler": "GCC", "version": "8", "os": "ubuntu-18.04", "buildType": "Release"},
-                    {"name": "GCC 9 Debug", "compiler": "GCC", "version": "9", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "GCC 9 Release", "compiler": "GCC", "version": "9", "os": "ubuntu-18.04", "buildType": "Release"},
-                    {"name": "GCC 10 Debug", "compiler": "GCC", "version": "10", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "GCC 10 Release", "compiler": "GCC", "version": "10", "os": "ubuntu-18.04", "buildType": "Release"},
-                    {"name": "CLANG 3.9 Debug", "compiler": "CLANG", "version": "3.9", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "CLANG 3.9 Release", "compiler": "CLANG", "version": "3.9", "os": "ubuntu-18.04", "buildType": "Release"},
-                    {"name": "CLANG 4.0 Debug", "compiler": "CLANG", "version": "4.0", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "CLANG 4.0 Release", "compiler": "CLANG", "version": "4.0", "os": "ubuntu-18.04", "buildType": "Release"},
-                    {"name": "CLANG 5.0 Debug", "compiler": "CLANG", "version": "5.0", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "CLANG 5.0 Release", "compiler": "CLANG", "version": "5.0", "os": "ubuntu-18.04", "buildType": "Release"},
-                    {"name": "CLANG 6.0 Debug", "compiler": "CLANG", "version": "6.0", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "CLANG 6.0 Release", "compiler": "CLANG", "version": "6.0", "os": "ubuntu-18.04", "buildType": "Release"},
-                    {"name": "CLANG 7.0 Debug", "compiler": "CLANG", "version": "7.0", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "CLANG 7.0 Release", "compiler": "CLANG", "version": "7.0", "os": "ubuntu-18.04", "buildType": "Release"},
-                    {"name": "CLANG 8 Debug", "compiler": "CLANG", "version": "8", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "CLANG 8 Release", "compiler": "CLANG", "version": "8", "os": "ubuntu-18.04", "buildType": "Release"},
-                    {"name": "CLANG 9 Debug", "compiler": "CLANG", "version": "9", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "CLANG 9 Release", "compiler": "CLANG", "version": "9", "os": "ubuntu-18.04", "buildType": "Release"},
-                    {"name": "CLANG 10 Debug", "compiler": "CLANG", "version": "10", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "CLANG 10 Release", "compiler": "CLANG", "version": "10", "os": "ubuntu-18.04", "buildType": "Release"},
-                    {"name": "CLANG 11 Debug", "compiler": "CLANG", "version": "11", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "CLANG 11 Release", "compiler": "CLANG", "version": "11", "os": "ubuntu-18.04", "buildType": "Release"},
+            matrix["config"] = [
+                {"name": "GCC 4.9", "compiler": "GCC", "version": "4.9", "os": "ubuntu-18.04"},
+                {"name": "GCC 5", "compiler": "GCC", "version": "5", "os": "ubuntu-18.04"},
+                {"name": "GCC 6", "compiler": "GCC", "version": "6", "os": "ubuntu-18.04"},
+                {"name": "GCC 7", "compiler": "GCC", "version": "7", "os": "ubuntu-18.04"},
+                {"name": "GCC 8", "compiler": "GCC", "version": "8", "os": "ubuntu-18.04"},
+                {"name": "GCC 9", "compiler": "GCC", "version": "9", "os": "ubuntu-18.04"},
+                {"name": "GCC 10", "compiler": "GCC", "version": "10", "os": "ubuntu-18.04"},
+                {"name": "CLANG 3.9", "compiler": "CLANG", "version": "3.9", "os": "ubuntu-18.04"},
+                {"name": "CLANG 4.0", "compiler": "CLANG", "version": "4.0", "os": "ubuntu-18.04"},
+                {"name": "CLANG 5.0", "compiler": "CLANG", "version": "5.0", "os": "ubuntu-18.04"},
+                {"name": "CLANG 6.0", "compiler": "CLANG", "version": "6.0", "os": "ubuntu-18.04"},
+                {"name": "CLANG 7.0", "compiler": "CLANG", "version": "7.0", "os": "ubuntu-18.04"},
+                {"name": "CLANG 8", "compiler": "CLANG", "version": "8", "os": "ubuntu-18.04"},
+                {"name": "CLANG 9", "compiler": "CLANG", "version": "9", "os": "ubuntu-18.04"},
+                {"name": "CLANG 10", "compiler": "CLANG", "version": "10", "os": "ubuntu-18.04"},
+                {"name": "CLANG 11", "compiler": "CLANG", "version": "11", "os": "ubuntu-18.04"},
+            ]
+            if run_macos:
+                matrix["config"] += [
+                    {"name": "macOS Apple-Clang 10", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.14"},
+                    {"name": "macOS Apple-Clang 11", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
+                    {"name": "macOS Apple-Clang 12", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
                 ]
-                if run_macos:
-                    matrix["config"] += [
-                        {"name": "macOS Apple-Clang 10 Release", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.14", "buildType": "Release"},
-                        {"name": "macOS Apple-Clang 10 Debug", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.14", "buildType": "Debug"},
-                        {"name": "macOS Apple-Clang 11 Release", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15", "buildType": "Release"},
-                        {"name": "macOS Apple-Clang 11 Debug", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15", "buildType": "Debug"},
-                        {"name": "macOS Apple-Clang 12 Release", "compiler": "APPLE_CLANG", "version": "12.0", "os": "macOS-10.15", "buildType": "Release"},
-                        {"name": "macOS Apple-Clang 12 Debug", "compiler": "APPLE_CLANG", "version": "12.0", "os": "macOS-10.15", "buildType": "Debug"},
-                    ]
-                if run_windows:
-                    matrix["config"] += [
-                        {"name": "Windows VS 2017 Release", "compiler": "VISUAL", "version": "15", "os": "vs2017-win2016", "buildType": "Release"},
-                        {"name": "Windows VS 2017 Debug", "compiler": "VISUAL", "version": "15", "os": "vs2017-win2016", "buildType": "Debug"},
-                        {"name": "Windows VS 2019 Release", "compiler": "VISUAL", "version": "16", "os": "windows-2019", "buildType": "Release"},
-                        {"name": "Windows VS 2019 Debug", "compiler": "VISUAL", "version": "16", "os": "windows-2019", "buildType": "Debug"},
-                    ]
-                matrix_minimal["config"] = [
-                    {"name": "GCC 7 Debug", "compiler": "GCC", "version": "7", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "GCC 7 Release", "compiler": "GCC", "version": "7", "os": "ubuntu-18.04", "buildType": "Release"},
-                    {"name": "CLANG 8 Debug", "compiler": "CLANG", "version": "8", "os": "ubuntu-18.04", "buildType": "Debug"},
-                    {"name": "CLANG 8 Release", "compiler": "CLANG", "version": "8", "os": "ubuntu-18.04", "buildType": "Release"},
+            if run_windows:
+                matrix["config"] += [
+                    {"name": "Windows VS 2017", "compiler": "VISUAL", "version": "15", "os": "vs2017-win2016"},
+                    {"name": "Windows VS 2019", "compiler": "VISUAL", "version": "16", "os": "windows-2019"},
                 ]
-                if run_macos:
-                    matrix_minimal["config"] += [
-                        {"name": "macOS Apple-Clang 11 Debug", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15", "buildType": "Debug"},
-                        {"name": "macOS Apple-Clang 11 Release", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15", "buildType": "Release"},
-                    ]
-                if run_windows:
-                    matrix_minimal["config"] += [
-                        {"name": "Windows VS 2019 Debug", "compiler": "VISUAL", "version": "16", "os": "windows-2019", "buildType": "Debug"},
-                        {"name": "Windows VS 2019 Release", "compiler": "VISUAL", "version": "16", "os": "windows-2019", "buildType": "Release"},
-                    ]
-            else:
-                matrix["config"] = [
-                    {"name": "GCC 4.9", "compiler": "GCC", "version": "4.9", "os": "ubuntu-18.04"},
-                    {"name": "GCC 5", "compiler": "GCC", "version": "5", "os": "ubuntu-18.04"},
-                    {"name": "GCC 6", "compiler": "GCC", "version": "6", "os": "ubuntu-18.04"},
-                    {"name": "GCC 7", "compiler": "GCC", "version": "7", "os": "ubuntu-18.04"},
-                    {"name": "GCC 8", "compiler": "GCC", "version": "8", "os": "ubuntu-18.04"},
-                    {"name": "GCC 9", "compiler": "GCC", "version": "9", "os": "ubuntu-18.04"},
-                    {"name": "GCC 10", "compiler": "GCC", "version": "10", "os": "ubuntu-18.04"},
-                    {"name": "CLANG 3.9", "compiler": "CLANG", "version": "3.9", "os": "ubuntu-18.04"},
-                    {"name": "CLANG 4.0", "compiler": "CLANG", "version": "4.0", "os": "ubuntu-18.04"},
-                    {"name": "CLANG 5.0", "compiler": "CLANG", "version": "5.0", "os": "ubuntu-18.04"},
-                    {"name": "CLANG 6.0", "compiler": "CLANG", "version": "6.0", "os": "ubuntu-18.04"},
-                    {"name": "CLANG 7.0", "compiler": "CLANG", "version": "7.0", "os": "ubuntu-18.04"},
-                    {"name": "CLANG 8", "compiler": "CLANG", "version": "8", "os": "ubuntu-18.04"},
-                    {"name": "CLANG 9", "compiler": "CLANG", "version": "9", "os": "ubuntu-18.04"},
-                    {"name": "CLANG 10", "compiler": "CLANG", "version": "10", "os": "ubuntu-18.04"},
-                    {"name": "CLANG 11", "compiler": "CLANG", "version": "11", "os": "ubuntu-18.04"},
+            matrix_minimal["config"] = [
+                {"name": "GCC 7", "compiler": "GCC", "version": "7", "os": "ubuntu-18.04"},
+                {"name": "CLANG 8", "compiler": "CLANG", "version": "8", "os": "ubuntu-18.04"},
+            ]
+            if run_macos:
+                matrix_minimal["config"] += [
+                    {"name": "macOS Apple-Clang 11", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
                 ]
-                if run_macos:
-                    matrix["config"] += [
-                        {"name": "macOS Apple-Clang 10", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.14"},
-                        {"name": "macOS Apple-Clang 11", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
-                        {"name": "macOS Apple-Clang 12", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
-                    ]
-                if run_windows:
-                    matrix["config"] += [
-                        {"name": "Windows VS 2017", "compiler": "VISUAL", "version": "15", "os": "vs2017-win2016"},
-                        {"name": "Windows VS 2019", "compiler": "VISUAL", "version": "16", "os": "windows-2019"},
-                    ]
-                matrix_minimal["config"] = [
-                    {"name": "GCC 7", "compiler": "GCC", "version": "7", "os": "ubuntu-18.04"},
-                    {"name": "CLANG 8", "compiler": "CLANG", "version": "8", "os": "ubuntu-18.04"},
+            if run_windows:
+                matrix_minimal["config"] += [
+                    {"name": "Windows VS 2019", "compiler": "VISUAL", "version": "16", "os": "windows-2019"},
                 ]
-                if run_macos:
-                    matrix_minimal["config"] += [
-                        {"name": "macOS Apple-Clang 11", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
-                    ]
-                if run_windows:
-                    matrix_minimal["config"] += [
-                        {"name": "Windows VS 2019", "compiler": "VISUAL", "version": "16", "os": "windows-2019"},
-                    ]
     elif platform == "azp":
-        if split_by_build_types:
-            matrix["config"] = [
-                {"name": "macOS Apple-Clang 10 Release", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.14", "buildType": "Release"},
-                {"name": "macOS Apple-Clang 10 Debug", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.14", "buildType": "Debug"},
-                {"name": "macOS Apple-Clang 11 Release", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15", "buildType": "Release"},
-                {"name": "macOS Apple-Clang 11 Debug", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15", "buildType": "Debug"},
-                {"name": "macOS Apple-Clang 12 Release", "compiler": "APPLE_CLANG", "version": "12.0", "os": "macOS-10.15", "buildType": "Release"},
-                {"name": "macOS Apple-Clang 12 Debug", "compiler": "APPLE_CLANG", "version": "12.0", "os": "macOS-10.15", "buildType": "Debug"},
-                {"name": "Windows VS 2017 Release", "compiler": "VISUAL", "version": "15", "os": "vs2017-win2016", "buildType": "Release"},
-                {"name": "Windows VS 2017 Debug", "compiler": "VISUAL", "version": "15", "os": "vs2017-win2016", "buildType": "Debug"},
-                {"name": "Windows VS 2019 Release", "compiler": "VISUAL", "version": "16", "os": "windows-2019", "buildType": "Release"},
-                {"name": "Windows VS 2019 Debug", "compiler": "VISUAL", "version": "16", "os": "windows-2019", "buildType": "Debug"},
-            ]
-            matrix_minimal["config"] = [
-                {"name": "macOS Apple-Clang 11 Debug", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15", "buildType": "Debug"},
-                {"name": "macOS Apple-Clang 11 Release", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15", "buildType": "Release"},
-                {"name": "Windows VS 2019 Debug", "compiler": "VISUAL", "version": "16", "os": "windows-2019", "buildType": "Debug"},
-                {"name": "Windows VS 2019 Release", "compiler": "VISUAL", "version": "16", "os": "windows-2019", "buildType": "Release"},
-            ]
-        else:
-            matrix["config"] = [
-                {"name": "macOS Apple-Clang 10", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.14"},
-                {"name": "macOS Apple-Clang 11", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
-                {"name": "macOS Apple-Clang 12", "compiler": "APPLE_CLANG", "version": "12.0", "os": "macOS-10.15"},
-                {"name": "Windows VS 2017", "compiler": "VISUAL", "version": "15", "os": "vs2017-win2016"},
-                {"name": "Windows VS 2019", "compiler": "VISUAL", "version": "16", "os": "windows-2019"},
-            ]
-            matrix_minimal["config"] = [
-                {"name": "macOS Apple-Clang 11", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
-                {"name": "Windows VS 2019", "compiler": "VISUAL", "version": "16", "os": "windows-2019"},
-            ]
+        matrix["config"] = [
+            {"name": "macOS Apple-Clang 10", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.14"},
+            {"name": "macOS Apple-Clang 11", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
+            {"name": "macOS Apple-Clang 12", "compiler": "APPLE_CLANG", "version": "12.0", "os": "macOS-10.15"},
+            {"name": "Windows VS 2017", "compiler": "VISUAL", "version": "15", "os": "vs2017-win2016"},
+            {"name": "Windows VS 2019", "compiler": "VISUAL", "version": "16", "os": "windows-2019"},
+        ]
+        matrix_minimal["config"] = [
+            {"name": "macOS Apple-Clang 11", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
+            {"name": "Windows VS 2019", "compiler": "VISUAL", "version": "16", "os": "windows-2019"},
+        ]
+
+    # Split build jobs by build_type (Debug, Release)
+    # Duplicate each builds job, then add the buildType value
+    if split_by_build_types is None:
+        # env var BPT_SPLIT_BY_BUILD_TYPES should be preferred over splitByBuildTypes (deprecated)
+        split_by_build_types = get_bool_from_env("BPT_SPLIT_BY_BUILD_TYPES", get_bool_from_env("splitByBuildTypes", False))
+
+    if split_by_build_types:
+        matrix_tmp = copy.deepcopy(matrix)
+        matrix_minimal_tmp = copy.deepcopy(matrix_minimal)
+
+        for m_tmp, m in [[matrix_tmp, matrix], [matrix_minimal_tmp, matrix_minimal]]:
+            for i, config_set in enumerate(m_tmp["config"], start=0):
+                m["config"].insert((i*2)+1, config_set.copy())
+            for config_set in m["config"][0::2]:
+                config_set["buildType"] = "Release"
+            for config_set in m["config"][1::2]:
+                config_set["buildType"] = "Debug"
 
     directory_structure = autodetect_directory_structure()
     final_matrix = {"config": []}

--- a/bincrafters/generate_ci_jobs.py
+++ b/bincrafters/generate_ci_jobs.py
@@ -56,6 +56,7 @@ def _get_base_config(recipe_directory: str, platform: str, split_by_build_types:
             ]
             matrix_minimal["config"] = matrix["config"].copy()
         else:
+            # TODO: Remove Clang 3.9 for >= 0.33.0 release
             matrix["config"] = [
                 {"name": "GCC 4.9", "compiler": "GCC", "version": "4.9", "os": "ubuntu-18.04"},
                 {"name": "GCC 5", "compiler": "GCC", "version": "5", "os": "ubuntu-18.04"},

--- a/bincrafters/generate_ci_jobs.py
+++ b/bincrafters/generate_ci_jobs.py
@@ -42,7 +42,7 @@ def generate_ci_jobs(platform: str, recipe_type: str = autodetect(), split_by_bu
         run_windows = _run_windows_jobs_on_gha()
         if recipe_type == "installer":
             matrix["config"] = [
-                {"name": "Installer Linux", "compiler": "GCC", "version": "7", "os": "ubuntu-18.04", "dockerImage": "conanio/gcc8"},
+                {"name": "Installer Linux", "compiler": "GCC", "version": "7", "os": "ubuntu-18.04", "dockerImage": "conanio/gcc7"},
                 {"name": "Installer Windows", "compiler": "VISUAL", "version": "16", "os": "windows-2019"},
                 {"name": "Installer macOS", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macos-10.15"}
             ]

--- a/bincrafters/generate_ci_jobs.py
+++ b/bincrafters/generate_ci_jobs.py
@@ -76,7 +76,7 @@ def _get_base_config(recipe_directory: str, platform: str, split_by_build_types:
             ]
             if run_macos:
                 matrix["config"] += [
-                    {"name": "macOS Apple-Clang 10", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.14"},
+                    {"name": "macOS Apple-Clang 10", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.15"},
                     {"name": "macOS Apple-Clang 11", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
                     {"name": "macOS Apple-Clang 12", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
                 ]
@@ -99,7 +99,7 @@ def _get_base_config(recipe_directory: str, platform: str, split_by_build_types:
                 ]
     elif platform == "azp":
         matrix["config"] = [
-            {"name": "macOS Apple-Clang 10", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.14"},
+            {"name": "macOS Apple-Clang 10", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.15"},
             {"name": "macOS Apple-Clang 11", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
             {"name": "macOS Apple-Clang 12", "compiler": "APPLE_CLANG", "version": "12.0", "os": "macOS-10.15"},
             {"name": "Windows VS 2017", "compiler": "VISUAL", "version": "15", "os": "vs2017-win2016"},

--- a/bincrafters/requirements.txt
+++ b/bincrafters/requirements.txt
@@ -1,2 +1,2 @@
-conan_package_tools>=0.35.0
+conan_package_tools>=0.35.1
 # conan-package-tools @ git+https://github.com/croydon/conan-package-tools@develop


### PR DESCRIPTION
In ongoing work to simplify the creation of Conan recipes by library
authors I've been finding ways to reduce the "fluff" from recipes.
Once such aspect is needing to have a CCI structure to support multiple
versions in the basic standalone recipe. This makes it possible to have
a dual "conanfile.py" and "conandata.yml" set of files arrangement.
Where the "conandata.yml" has the version information. Hence one can
write a generic standalone recipe that's controlled with version info
from the changing "conandata.yml" sibbling file. An example, and
testbed, of such a recipe is https://github.com/grafikrobot/hash-predef