### PR TITLE
v1.0.0

### DIFF
--- a/.github/workflows/package-tools.yml
+++ b/.github/workflows/package-tools.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: ["ubuntu-20.04", "windows-2019", "macos-10.15"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: "3.8"
@@ -33,7 +33,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     needs: bincrafters-package-tools-test
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: "3.8"

--- a/.github/workflows/package-tools.yml
+++ b/.github/workflows/package-tools.yml
@@ -12,7 +12,7 @@ jobs:
         os: ["ubuntu-20.04", "windows-2019", "macos-10.15"]
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.8"
     - name: "Build & Test"
@@ -34,7 +34,7 @@ jobs:
     needs: bincrafters-package-tools-test
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.8"
     - name: Build

--- a/bincrafters/__init__.py
+++ b/bincrafters/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '0.33.0'
+__version__ = '1.0.0-alpha1'

--- a/bincrafters/generate_ci_jobs.py
+++ b/bincrafters/generate_ci_jobs.py
@@ -82,12 +82,6 @@ def _get_base_config(recipe_directory: str, platform: str, split_by_build_types:
                 {"name": "GCC 9", "compiler": "GCC", "version": "9", "os": "ubuntu-18.04"},
                 {"name": "GCC 10", "compiler": "GCC", "version": "10", "os": "ubuntu-18.04"},
                 {"name": "GCC 11", "compiler": "GCC", "version": "11", "os": "ubuntu-18.04"},
-                {"name": "CLANG 4.0", "compiler": "CLANG", "version": "4.0", "os": "ubuntu-18.04"},
-                {"name": "CLANG 5.0", "compiler": "CLANG", "version": "5.0", "os": "ubuntu-18.04"},
-                {"name": "CLANG 6.0", "compiler": "CLANG", "version": "6.0", "os": "ubuntu-18.04"},
-                {"name": "CLANG 7.0", "compiler": "CLANG", "version": "7.0", "os": "ubuntu-18.04"},
-                {"name": "CLANG 8", "compiler": "CLANG", "version": "8", "os": "ubuntu-18.04"},
-                {"name": "CLANG 9", "compiler": "CLANG", "version": "9", "os": "ubuntu-18.04"},
                 {"name": "CLANG 10", "compiler": "CLANG", "version": "10", "os": "ubuntu-18.04"},
                 {"name": "CLANG 11", "compiler": "CLANG", "version": "11", "os": "ubuntu-18.04"},
                 {"name": "CLANG 12", "compiler": "CLANG", "version": "12", "os": "ubuntu-18.04"},
@@ -105,7 +99,7 @@ def _get_base_config(recipe_directory: str, platform: str, split_by_build_types:
                 ]
             matrix_minimal["config"] = [
                 {"name": "GCC 7", "compiler": "GCC", "version": "7", "os": "ubuntu-18.04"},
-                {"name": "CLANG 8", "compiler": "CLANG", "version": "8", "os": "ubuntu-18.04"},
+                {"name": "CLANG 10", "compiler": "CLANG", "version": "10", "os": "ubuntu-18.04"},
             ]
             if run_macos:
                 matrix_minimal["config"] += [

--- a/bincrafters/generate_ci_jobs.py
+++ b/bincrafters/generate_ci_jobs.py
@@ -61,30 +61,30 @@ def _get_base_config(recipe_directory: str, platform: str, split_by_build_types:
         run_windows = _run_windows_jobs_on_gha()
         if recipe_type == "installer":
             matrix["config"] = [
-                {"name": "Installer Linux", "compiler": "GCC", "version": "7", "os": "ubuntu-18.04", "dockerImage": "conanio/gcc7"},
+                {"name": "Installer Linux", "compiler": "GCC", "version": "7", "os": "ubuntu-20.04", "dockerImage": "conanio/gcc7"},
                 {"name": "Installer Windows", "compiler": "VISUAL", "version": "16", "os": "windows-2019"},
                 {"name": "Installer macOS", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macos-10.15"}
             ]
             matrix_minimal["config"] = matrix["config"].copy()
         elif recipe_type == "unconditional_header_only":
             matrix["config"] = [
-                {"name": "Header-only Linux", "compiler": "CLANG", "version": "8", "os": "ubuntu-18.04"},
+                {"name": "Header-only Linux", "compiler": "CLANG", "version": "8", "os": "ubuntu-20.04"},
                 {"name": "Header-only Windows", "compiler": "VISUAL", "version": "16", "os": "windows-latest"}
             ]
             matrix_minimal["config"] = matrix["config"].copy()
         else:
             matrix["config"] = [
-                {"name": "GCC 5", "compiler": "GCC", "version": "5", "os": "ubuntu-18.04"},
-                {"name": "GCC 6", "compiler": "GCC", "version": "6", "os": "ubuntu-18.04"},
-                {"name": "GCC 7", "compiler": "GCC", "version": "7", "os": "ubuntu-18.04"},
-                {"name": "GCC 8", "compiler": "GCC", "version": "8", "os": "ubuntu-18.04"},
-                {"name": "GCC 9", "compiler": "GCC", "version": "9", "os": "ubuntu-18.04"},
-                {"name": "GCC 10", "compiler": "GCC", "version": "10", "os": "ubuntu-18.04"},
-                {"name": "GCC 11", "compiler": "GCC", "version": "11", "os": "ubuntu-18.04"},
-                {"name": "CLANG 10", "compiler": "CLANG", "version": "10", "os": "ubuntu-18.04"},
-                {"name": "CLANG 11", "compiler": "CLANG", "version": "11", "os": "ubuntu-18.04"},
-                {"name": "CLANG 12", "compiler": "CLANG", "version": "12", "os": "ubuntu-18.04"},
-                {"name": "CLANG 13", "compiler": "CLANG", "version": "13", "os": "ubuntu-18.04"},
+                {"name": "GCC 5", "compiler": "GCC", "version": "5", "os": "ubuntu-20.04"},
+                {"name": "GCC 6", "compiler": "GCC", "version": "6", "os": "ubuntu-20.04"},
+                {"name": "GCC 7", "compiler": "GCC", "version": "7", "os": "ubuntu-20.04"},
+                {"name": "GCC 8", "compiler": "GCC", "version": "8", "os": "ubuntu-20.04"},
+                {"name": "GCC 9", "compiler": "GCC", "version": "9", "os": "ubuntu-20.04"},
+                {"name": "GCC 10", "compiler": "GCC", "version": "10", "os": "ubuntu-20.04"},
+                {"name": "GCC 11", "compiler": "GCC", "version": "11", "os": "ubuntu-20.04"},
+                {"name": "CLANG 10", "compiler": "CLANG", "version": "10", "os": "ubuntu-20.04"},
+                {"name": "CLANG 11", "compiler": "CLANG", "version": "11", "os": "ubuntu-20.04"},
+                {"name": "CLANG 12", "compiler": "CLANG", "version": "12", "os": "ubuntu-20.04"},
+                {"name": "CLANG 13", "compiler": "CLANG", "version": "13", "os": "ubuntu-20.04"},
             ]
             if run_macos:
                 matrix["config"] += [
@@ -97,8 +97,8 @@ def _get_base_config(recipe_directory: str, platform: str, split_by_build_types:
                     # {"name": "Windows VS 2022 - Testing", "compiler": "VISUAL", "version": "17", "os": "windows-2022"},
                 ]
             matrix_minimal["config"] = [
-                {"name": "GCC 7", "compiler": "GCC", "version": "7", "os": "ubuntu-18.04"},
-                {"name": "CLANG 10", "compiler": "CLANG", "version": "10", "os": "ubuntu-18.04"},
+                {"name": "GCC 7", "compiler": "GCC", "version": "7", "os": "ubuntu-20.04"},
+                {"name": "CLANG 10", "compiler": "CLANG", "version": "10", "os": "ubuntu-20.04"},
             ]
             if run_macos:
                 matrix_minimal["config"] += [

--- a/bincrafters/generate_ci_jobs.py
+++ b/bincrafters/generate_ci_jobs.py
@@ -84,6 +84,7 @@ def _get_base_config(recipe_directory: str, platform: str, split_by_build_types:
                 {"name": "CLANG 10", "compiler": "CLANG", "version": "10", "os": "ubuntu-18.04"},
                 {"name": "CLANG 11", "compiler": "CLANG", "version": "11", "os": "ubuntu-18.04"},
                 {"name": "CLANG 12", "compiler": "CLANG", "version": "12", "os": "ubuntu-18.04"},
+                {"name": "CLANG 13", "compiler": "CLANG", "version": "13", "os": "ubuntu-18.04"},
             ]
             if run_macos:
                 matrix["config"] += [

--- a/bincrafters/generate_ci_jobs.py
+++ b/bincrafters/generate_ci_jobs.py
@@ -74,7 +74,6 @@ def _get_base_config(recipe_directory: str, platform: str, split_by_build_types:
             matrix_minimal["config"] = matrix["config"].copy()
         else:
             matrix["config"] = [
-                {"name": "GCC 4.9", "compiler": "GCC", "version": "4.9", "os": "ubuntu-18.04"},
                 {"name": "GCC 5", "compiler": "GCC", "version": "5", "os": "ubuntu-18.04"},
                 {"name": "GCC 6", "compiler": "GCC", "version": "6", "os": "ubuntu-18.04"},
                 {"name": "GCC 7", "compiler": "GCC", "version": "7", "os": "ubuntu-18.04"},

--- a/bincrafters/generate_ci_jobs.py
+++ b/bincrafters/generate_ci_jobs.py
@@ -87,7 +87,6 @@ def _get_base_config(recipe_directory: str, platform: str, split_by_build_types:
             ]
             if run_macos:
                 matrix["config"] += [
-                    {"name": "macOS Apple-Clang 10", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.15"},
                     {"name": "macOS Apple-Clang 11", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
                     {"name": "macOS Apple-Clang 12", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
                 ]
@@ -114,7 +113,6 @@ def _get_base_config(recipe_directory: str, platform: str, split_by_build_types:
             matrix_minimal["config"] = []
         else:
             matrix["config"] = [
-                {"name": "macOS Apple-Clang 10", "compiler": "APPLE_CLANG", "version": "10.0", "os": "macOS-10.15"},
                 {"name": "macOS Apple-Clang 11", "compiler": "APPLE_CLANG", "version": "11.0", "os": "macOS-10.15"},
                 {"name": "macOS Apple-Clang 12", "compiler": "APPLE_CLANG", "version": "12.0", "os": "macOS-10.15"},
                 {"name": "Windows VS 2019", "compiler": "VISUAL", "version": "16", "os": "windows-2019"},

--- a/bincrafters/prepare_env.py
+++ b/bincrafters/prepare_env.py
@@ -57,12 +57,9 @@ def prepare_env(platform: str, config: json, select_config: str = None):
             version_without_dot = compiler_version.replace(".", "")
             image_suffix = ""
             # Use "modern" CDT containers for newer compilers
-            if (compiler == "GCC" and float(compiler_version) >= 12) or \
-                    (compiler == "CLANG" and float(compiler_version) >= 14):
+            if (compiler == "GCC" and float(compiler_version) >= 11) or \
+                    (compiler == "CLANG" and float(compiler_version) >= 10):
                 image_suffix = "-ubuntu18.04"
-            elif (compiler == "GCC" and float(compiler_version) >= 11) or \
-                    (compiler == "CLANG" and float(compiler_version) >= 12):
-                image_suffix = "-ubuntu16.04"
 
             docker_image = "conanio/{}{}{}".format(compiler_lower, version_without_dot, image_suffix)
         _set_env_variable("CONAN_DOCKER_IMAGE", docker_image)


### PR DESCRIPTION
Bincrafters Package Tools is now using semantic versioning more strictly, hence the major version bump due to the following breaking changes.

## Breaking Changes / Removed features
  * Remove GCC 4.9 builds from the default build matrix
  * Remove Apple Clang 10 builds from the default build matrix
  * Remove Clang < 10 builds from the default build matrix
  * Upgrade Clang >= 12 container base from `ubuntu16.04` to `ubuntu18.04`; this might cause incompatibilities with existing binary packages and setups
  * Upgrade GCC 11 container base from `ubuntu16.04` to `ubuntu18.04`; this might cause incompatibilities with existing binary packages and setups
  * This means Bincrafters Package Tools is not using any modern container image with `ubuntu16.04` as base anymore
  * The usage of the [modern Conan Docker Tools containers](https://github.com/conan-io/conan-docker-tools/tree/fe6fd76caa7b9f06bf2edff418689405bbabbaa7/modern) is extended to Clang >= 10 builds with `ubuntu18.04` as base; this might cause incompatibilities with existing binaray packages and setups
  * 


## Deprecated Features / Will be removed in a future release


## Upcoming Features Early Notice


## New Features
  * Add Clang 13 builds to the default build matrix


## Other Improvements


## Bugfixes


## Internal Improvements 
  * Update CI runner image for executing containers from Ubuntu 18.04 to Ubuntu 20.04
    * This is the CI host runner image on which the Docker host is running
    * This does NOT affect which Ubuntu version is running INSIDE the containers!


## TODO
  * Use `pyproject.toml` for setup
  * Use the Conan 2.x behaviour to always use 2 profiles (host and build) - This might break old recipes
  * Support for AppVeyor CI is deprecated. AppVeyor does not allow dynamic matrix generations which we need for most modern features.
  * Don't fail when GHA or AZP don't get any build jobs on purpose (requires changes in templates and tooling; breaking change; e.g. for [installers](https://github.com/bincrafters/community/pull/1387) when AZP shouldn't run at all or changes that don't affect any Conan recipe in a repository)
  * Installer build job names have double `Release` in their names: https://github.com/bincrafters/community/runs/3781824922?check_suite_focus=true
  * Figure out VS 2022 support ~~Testing builds will be migrated to the new Conan `MSVC` compiler model, once upstream support is done (see https://github.com/conan-io/conan-package-tools/issues/580)~~
